### PR TITLE
fix：修复 useDict 的 watchEffect 依赖过多问题

### DIFF
--- a/src/components/Dict/useDict.ts
+++ b/src/components/Dict/useDict.ts
@@ -12,8 +12,8 @@ export const useDict = (props: DictComponentProps) => {
 
   const dictItems = ref<DictItem[]>([])
 
-  watchEffect(() => {
-    dictStore.getDictData(props.dictCode).then(dictData => {
+  watch(props,(newVal,oldVal) => {
+    dictStore.getDictData(newVal.dictCode).then(dictData => {
       if (!dictData) return
 
       const result = []
@@ -43,7 +43,9 @@ export const useDict = (props: DictComponentProps) => {
 
       dictItems.value = result
     })
-  })
+  },
+  { immediate: true }
+  )
 
   return dictItems
 }


### PR DESCRIPTION
bug ：执行 useDict({dictCode:""}) 时候，如果 dictCode 在后台没有定义，字典请求接口响应成功返回空的列表，但是接口会不断重复请求，进入死循环

原因：src/components/Dict/useDict.ts 中，useDict 中使用 watchEffect 函数中收集了不必要的依赖。 dictCode 在后台没有定义时候，字典请求接口响应成功， dict-store 中有锁标识变化，触发 watchEffect 的副作用，导致死循环

解决：watchEffect 替换为 watch ，只监测 useDict 函数的参数变动