### PR TITLE
:bug: 修复通知已读操作未生效的问题

### DIFF
--- a/src/api/notify/announcement/index.ts
+++ b/src/api/notify/announcement/index.ts
@@ -1,10 +1,10 @@
 import httpClient from '@/utils/axios'
 import type { ApiResult } from '@/api/types'
 import type {
-  Announcement,
   AnnouncementDTO,
   AnnouncementPageParam,
-  AnnouncementPageVO
+  AnnouncementPageVO,
+  UserAnnouncementVO
 } from './types'
 import type { FileObject } from '@/components/CropperModal/types'
 
@@ -71,7 +71,7 @@ export function uploadAnnouncementImage(resultFiles: FileObject[]) {
 }
 
 export function getUserAnnouncements() {
-  return httpClient.get<ApiResult<Announcement[]>>('/notify/announcement/user')
+  return httpClient.get<ApiResult<UserAnnouncementVO[]>>('/notify/user-announcement/list')
 }
 
 export function readAnnouncement(announcementId: number) {

--- a/src/api/notify/announcement/types.ts
+++ b/src/api/notify/announcement/types.ts
@@ -13,6 +13,16 @@ export enum AnnouncementStatusEnum {
 }
 
 /**
+ * 用户公告状态
+ */
+export enum UserAnnouncementStateEnum {
+  // 未读(0)
+  UNREAD = 0,
+  // 已读(1)
+  READ = 1
+}
+
+/**
  * 公告信息查询对象
  */
 export type AnnouncementQO = {
@@ -65,6 +75,28 @@ export type AnnouncementDTO = Omit<Announcement, 'id'> & {
  * 公告信息分页视图对象
  */
 export type AnnouncementPageVO = Announcement & {
+  // 创建人ID
+  createBy: number
+  // 创建人名称
+  createUsername: string
+  // 创建时间
+  createTime: string
+  // 更新时间
+  updateTime: string
+}
+
+/**
+ * 用户公告信息
+ */
+export type UserAnnouncementVO = {
+  //公告ID
+  id: number
+  //标题
+  title: string
+  //内容
+  content: string
+  //状态
+  state: UserAnnouncementStateEnum
   // 创建人ID
   createBy: number
   // 创建人名称

--- a/src/components/Notify/AnnouncementModal.tsx
+++ b/src/components/Notify/AnnouncementModal.tsx
@@ -1,15 +1,16 @@
 import { Modal } from 'ant-design-vue'
 import { readAnnouncement } from '@/api/notify/announcement'
-import type { AnnouncementDTO } from '@/api/notify/announcement/types'
+import { UserAnnouncementStateEnum, type UserAnnouncementVO } from '@/api/notify/announcement/types'
 import { NotificationOutlined } from '@ant-design/icons-vue'
 import { defineComponent } from 'vue'
 import '@wangeditor/editor/dist/css/style.css'
 import '@/components/Editor/view.less'
+import { emitter } from '@/hooks/mitt'
 
 export const AnnouncementModal = defineComponent({
   name: 'AnnouncementModal',
   setup(props, { expose }) {
-    function show(announcement: AnnouncementDTO, isPreview = false) {
+    function show(announcement: UserAnnouncementVO, isPreview = false) {
       Modal.info({
         title: announcement.title,
         width: 800,
@@ -18,8 +19,13 @@ export const AnnouncementModal = defineComponent({
         content: () => <div class="editor-content-view" innerHTML={announcement.content}></div>,
         onOk: function () {
           // 不是预览且状态是未读
-          if (!isPreview && announcement.status === 0) {
-            return readAnnouncement(announcement.id!)
+          if (!isPreview && announcement.state === UserAnnouncementStateEnum.UNREAD) {
+            return readAnnouncement(announcement.id!).then(() => {
+              emitter.emit('announcement-close', {
+                id: announcement.id!,
+                type: 'announcement-close'
+              })
+            })
           }
         }
       })

--- a/src/components/Notify/AnnouncementRibbon.vue
+++ b/src/components/Notify/AnnouncementRibbon.vue
@@ -19,6 +19,7 @@ import type {
   AnnouncementCloseMessage,
   AnnouncementPushMessage
 } from '@/api/notify/announcement/types'
+import { UserAnnouncementStateEnum } from '@/api/notify/announcement/types'
 
 const announcementModalRef = ref()
 
@@ -43,7 +44,8 @@ const onAnnouncementPush = (data: AnnouncementPushMessage) => {
   const announcement = {
     id: data.id,
     title: data.title,
-    content: data.content
+    content: data.content,
+    state: UserAnnouncementStateEnum.UNREAD
   }
   announcements.value.push(announcement)
 }


### PR DESCRIPTION
- 修复前端点击“我知道了”无法将通知公告标记为已读。
- 修复通过websocket推过来的通知公告无状态属性不会出发标记已读动作
 
ref ballcat-business[#10](https://github.com/ballcat-projects/ballcat-business/pull/10)